### PR TITLE
Adds new SendInBlue instructions. Adds new `twitgen` module for Markdown.

### DIFF
--- a/2016-09-10-TWIT.md
+++ b/2016-09-10-TWIT.md
@@ -20,14 +20,14 @@ Tessel Project leadership met up at Tesselcamp to determine the organization's g
 The two key goals for the next year are:
 
 1. **Grow the community to increase contributions and encourage both inclusion and accessibility to newcomers.**
-  * Build effective working groups that can complete their tasks with measurable results.
-  * Upgrade our documentation. Build more fritzing examples, API prototypes, and call out features that are currently missing from the docs.
-  * Update the tessel.io website to more accurately represent the project and its plans.
+   * Build effective working groups that can complete their tasks with measurable results.
+   * Upgrade our documentation. Build more fritzing examples, API prototypes, and call out features that are currently missing from the docs.
+   * Update the tessel.io website to more accurately represent the project and its plans.
 2. **Support and grow the number of production deployments of Tessel in the field.**
-  * Research and create a guide for production-scale deployment of a Tessel project. Base this on the needs of current users.
-  * Build Tessel Reach, the low-power hardware endpoints of a star network whose center is Tessel 2, so Tessel can make sense in more use cases.
-  * Build first-class support for Rust API and documentation (parity with JS) and figure out JS-Rust inter-exection to provide for performant high-level coding of serious applications.
-  * Investigate increasing RAM and Flash availability on Tessel or a revision of the Tessel board, reducing friction in production-level deployments.
+   * Research and create a guide for production-scale deployment of a Tessel project. Base this on the needs of current users.
+   * Build Tessel Reach, the low-power hardware endpoints of a star network whose center is Tessel 2, so Tessel can make sense in more use cases.
+   * Build first-class support for Rust API and documentation (parity with JS) and figure out JS-Rust inter-exection to provide for performant high-level coding of serious applications.
+   * Investigate increasing RAM and Flash availability on Tessel or a revision of the Tessel board, reducing friction in production-level deployments.
 
 [Read more in the Tessel Project readme](https://github.com/tessel/project#current-goals).
 

--- a/2016-09-10-TWIT.md
+++ b/2016-09-10-TWIT.md
@@ -20,14 +20,14 @@ Tessel Project leadership met up at Tesselcamp to determine the organization's g
 The two key goals for the next year are:
 
 1. **Grow the community to increase contributions and encourage both inclusion and accessibility to newcomers.**
-   * Build effective working groups that can complete their tasks with measurable results.
-   * Upgrade our documentation. Build more fritzing examples, API prototypes, and call out features that are currently missing from the docs.
-   * Update the tessel.io website to more accurately represent the project and its plans.
+  * Build effective working groups that can complete their tasks with measurable results.
+  * Upgrade our documentation. Build more fritzing examples, API prototypes, and call out features that are currently missing from the docs.
+  * Update the tessel.io website to more accurately represent the project and its plans.
 2. **Support and grow the number of production deployments of Tessel in the field.**
-   * Research and create a guide for production-scale deployment of a Tessel project. Base this on the needs of current users.
-   * Build Tessel Reach, the low-power hardware endpoints of a star network whose center is Tessel 2, so Tessel can make sense in more use cases.
-   * Build first-class support for Rust API and documentation (parity with JS) and figure out JS-Rust inter-exection to provide for performant high-level coding of serious applications.
-   * Investigate increasing RAM and Flash availability on Tessel or a revision of the Tessel board, reducing friction in production-level deployments.
+  * Research and create a guide for production-scale deployment of a Tessel project. Base this on the needs of current users.
+  * Build Tessel Reach, the low-power hardware endpoints of a star network whose center is Tessel 2, so Tessel can make sense in more use cases.
+  * Build first-class support for Rust API and documentation (parity with JS) and figure out JS-Rust inter-exection to provide for performant high-level coding of serious applications.
+  * Investigate increasing RAM and Flash availability on Tessel or a revision of the Tessel board, reducing friction in production-level deployments.
 
 [Read more in the Tessel Project readme](https://github.com/tessel/project#current-goals).
 

--- a/README.md
+++ b/README.md
@@ -52,18 +52,23 @@ Copy the template. Rename to include the date of intended publication in the fil
 
 **Create a new campaign**. Set the campaign and subject to the same name, e.g. "This Week in Tessel: *Some content here...*"
 
-![Select "Saved Templates" and click the "TWIT Reference".](https://cloud.githubusercontent.com/assets/80639/18758377/d995a3e6-80c5-11e6-8008-a52d43aaa7bd.png) You'll be brought to the responsive text editor.
+[Select "Saved Templates" and click the "TWIT Reference".](https://cloud.githubusercontent.com/assets/80639/18758377/d995a3e6-80c5-11e6-8008-a52d43aaa7bd.png) You'll be brought to the responsive text editor.
 
-The main text block has an HTML editor (the leftmost icon with angle brackets `<>` in it). The easiest way to convert the Markdown content for this email into HTML for the email is to use the `twitgen` NPM module, included in this repository.
+The main text block has an HTML editor (the leftmost icon with angle brackets `<>` in it). The easiest way to convert the Markdown content for this email into HTML for the email is to use the `twitgen` NPM module. It is included in this repository and can be installed:
 
 ```
-npm i -g twitgen
-twitgen 2016-09-10-TWIT.md
+$ npm i -g ./twitgen
 ```
 
-Copy the HTML into the responsive editor. If `twitgen` instructs you to in its output, split text blocks where a large image should be, adding an image section using the left toolbar in the responsive text editor.
+Then you are able to convert a markdown file locally into SendInBlue-compatible HTML:
 
-**Preview** using SendInBlue's [preview widgets](https://cloud.githubusercontent.com/assets/80639/18758404/f8a6c238-80c5-11e6-86fa-782b24bf89c8.png) to see the final rendering. (The final rendering will differ from the responsive editor.)
+```
+$ twitgen 2016-09-10-TWIT.md
+```
+
+Copy the HTML into the responsive editor. If instructed by the output of `twitgen`, split text blocks where a large image should be, adding an image section using the left toolbar in the responsive text editor.
+
+**Preview** using SendInBlue's [preview widgets](https://cloud.githubusercontent.com/assets/80639/18758404/f8a6c238-80c5-11e6-86fa-782b24bf89c8.png) to see the final rendering. (The editor will render content different than how it is sent; use the "preview" widget to see the final rendering as it would appear in an email.)
 
 When you **Save & Exit** the campaign email, while still in the **"Build"** step, scroll to the bottom to "Send a Test" to your email address. Be sure to send at least one test email and read it over carefully.
 

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Copy the template. Rename to include the date of intended publication in the fil
 
 ## Send the email
 
-**Create the campaign** using the [This Week in Tessel template](http://templates.mailchimp.com/getting-started/using-mailchimp/).
+**Create a new campaign**. Name the campaign something like "This Week in Tessel - Date". Set the subject to "This Week in Tessel: *Some content here...*"
 
-Name the campaign something like "This Week in Tessel - Date"
+![Select "Saved Templates" and click the "TWIT Reference".](https://cloud.githubusercontent.com/assets/80639/18758377/d995a3e6-80c5-11e6-8008-a52d43aaa7bd.png) You'll be brought to the responsive text editor.
 
-Copy and paste the rendered markdown from any markdown renderer, instead of using Mailchimp's specialized formatting (because, what a pain otherwise). Mailchimp handles this pretty gracefully, but read it over anyway just in case.
+Copy and paste the rendered markdown from any markdown renderer, instead of using Mailchimp's specialized formatting (because, what a pain otherwise). Mailchimp handles this pretty gracefully, but read it over anyway just in case. **Preview** using SendInBlue's [preview widgets](https://cloud.githubusercontent.com/assets/80639/18758404/f8a6c238-80c5-11e6-86fa-782b24bf89c8.png) to see the final rendering. (The final rendering will differ from the responsive editor.)
 
-**Preview** using Mailchimp's [preview and test menu](http://kb.mailchimp.com/campaigns/previews-and-tests/preview-and-test-your-campaign). Be sure to send at least one test email and read it over carefully.
+In the **2. Build** step, scroll to the bottom to "Send a Test" to your email address. Be sure to send at least one test email and read it over carefully.
 
 **Send!** Ideally sometime in the morning on a weekday.
 
-Also follow the blog-posting instructions.
+Also follow the blog-posting instructions above.

--- a/README.md
+++ b/README.md
@@ -50,13 +50,22 @@ Copy the template. Rename to include the date of intended publication in the fil
 
 ## Send the email
 
-**Create a new campaign**. Name the campaign something like "This Week in Tessel - Date". Set the subject to "This Week in Tessel: *Some content here...*"
+**Create a new campaign**. Set the campaign and subject to the same name, e.g. "This Week in Tessel: *Some content here...*"
 
 ![Select "Saved Templates" and click the "TWIT Reference".](https://cloud.githubusercontent.com/assets/80639/18758377/d995a3e6-80c5-11e6-8008-a52d43aaa7bd.png) You'll be brought to the responsive text editor.
 
-Copy and paste the rendered markdown from any markdown renderer, instead of using Mailchimp's specialized formatting (because, what a pain otherwise). Mailchimp handles this pretty gracefully, but read it over anyway just in case. **Preview** using SendInBlue's [preview widgets](https://cloud.githubusercontent.com/assets/80639/18758404/f8a6c238-80c5-11e6-86fa-782b24bf89c8.png) to see the final rendering. (The final rendering will differ from the responsive editor.)
+The main text block has an HTML editor (the leftmost icon with angle brackets `<>` in it). The easiest way to convert the Markdown content for this email into HTML for the email is to use the `twitgen` NPM module, included in this repository.
 
-In the **2. Build** step, scroll to the bottom to "Send a Test" to your email address. Be sure to send at least one test email and read it over carefully.
+```
+npm i -g twitgen
+twitgen 2016-09-10-TWIT.md
+```
+
+Copy the HTML into the responsive editor. If `twitgen` instructs you to in its output, split text blocks where a large image should be, adding an image section using the left toolbar in the responsive text editor.
+
+**Preview** using SendInBlue's [preview widgets](https://cloud.githubusercontent.com/assets/80639/18758404/f8a6c238-80c5-11e6-86fa-782b24bf89c8.png) to see the final rendering. (The final rendering will differ from the responsive editor.)
+
+When you **Save & Exit** the campaign email, while still in the **"Build"** step, scroll to the bottom to "Send a Test" to your email address. Be sure to send at least one test email and read it over carefully.
 
 **Send!** Ideally sometime in the morning on a weekday.
 

--- a/twitgen/.gitignore
+++ b/twitgen/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/twitgen/index.js
+++ b/twitgen/index.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var marked = require('marked');
+
+if (!process.argv[2]) {
+  console.error('Usage: twitgen input.md');
+  process.exit(1);
+}
+
+var input = fs.readFileSync(process.argv[2], 'utf-8');
+
+var renderer = new marked.Renderer();
+
+/*
+code(string code, string language)
+blockquote(string quote)
+html(string html)
+heading(string text, number level)
+hr()
+list(string body, boolean ordered)
+listitem(string text)
+paragraph(string text)
+table(string header, string body)
+tablerow(string content)
+tablecell(string content, object flags)
+*/
+
+renderer.heading = function (text, level) {
+  var fontSize = 18;
+  switch (level) {
+    case 1: fontSize = 24; break;
+    case 2: fontSize = 22; break;
+    case 3: fontSize = 20; break;
+    default: fontSize = 18; break;
+  }
+
+  return '<div style="font-size: ' + fontSize + 'px"><strong>' + text + '</strong></div><br>'
+};
+
+renderer.paragraph = function (text, level) {
+  if (text.match(/^\s*<img[^<]+?>\s*$/)) {
+    return '\n\n---\n\nSPLIT BLOCK HERE. ADD IMAGE MANUALLY: ' + text.replace(/(https[^"]+)/, '$1') + '\n\n---\n\n';
+  }
+  return '<div>' + text + '</div><br>'
+};
+
+var output = marked(input, { renderer: renderer });
+output = output.replace(/<\/ul>/g, '</ul><br>');
+output = output.replace(/<\/ol>/g, '</ol><br>');
+
+console.log(output);


### PR DESCRIPTION
Because SendInBlue isn't as graceful as MailChimp in adding Markdown, I added a `twitgen` module to make HTML you can copy/paste into the responsive editor which works well.
